### PR TITLE
Associer une réponse au projet + Partager une réponse

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -22,7 +22,7 @@ class ResponsesController < ApplicationController
   def create
     @response = Response.new
     @response.author = User.current
-    @response.project = params[:response][:project_id] ? Project.find(params[:response][:project_id]) : nil
+    @response.project = params[:response][:project_id].present? ? Project.find(params[:response][:project_id]) : nil
     @response.safe_attributes = params[:response]
     complete_response_attributes
 

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,6 +1,13 @@
 class ResponsesController < ApplicationController
 
+  before_action :find_optional_project, :only => [:index, :new, :create]
+
   def index
+    # #### TODO (using project_id or identifier) to discuss
+    if params[:project_id].present?
+      return @responses = [] unless Project.find(params[:project_id]).id.to_s == params[:project_id]
+    end
+    # ##############
     @responses = Response.sorted
     @project_id = params[:project_id]
     @responses = @responses.private_for_user(User.current) unless @project_id.present?

--- a/app/helpers/responses_helper.rb
+++ b/app/helpers/responses_helper.rb
@@ -3,7 +3,7 @@ module ResponsesHelper
     responses = issue.available_responses
     tags = "".html_safe
     blank_text = "-- #{l(:label_responses)} --"
-    tags << content_tag('option', blank_text, :value => '') if responses.size > 1
+    tags << content_tag('option', blank_text, :value => '') if responses.size > 0
     tags << options_for_select(responses.map { |r| [r.name, r.id] })
     tags
   end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -43,7 +43,9 @@ class Response < ActiveRecord::Base
   def self.global_for_project(user = User.current, project_id)
     scope = joins("INNER JOIN #{Project.table_name} ON #{table_name}.project_id = #{Project.table_name}.id").
       where("#{table_name}.project_id = ?", project_id)
+      # TODO (get responses with project_id nil but are public) to discuss
     if user.admin?
+      # TODO admin can use private responses of another users to discuss
       #scope.where("#{table_name}.visibility <> ?", VISIBILITY_PRIVATE)
       scope
     elsif user.memberships.any?

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -24,14 +24,40 @@ class Response < ActiveRecord::Base
   scope :not_private, -> { where(is_private: false) }
   scope :sorted, -> { order(:name) }
   scope :visible_by, ->(user) { where("is_private = ? OR author_id = ?", false, user.id) }
-
   before_save :remove_empty_value_from_serialized_field
 
   VISIBILITY_PRIVATE = 0
-  VISIBILITY_ROLES   = 1
   VISIBILITY_PUBLIC  = 2
+  VISIBILITY_ROLES   = 1
 
   validates :visibility, :inclusion => {:in => [VISIBILITY_PUBLIC, VISIBILITY_ROLES, VISIBILITY_PRIVATE]}
+  scope :private_for_user, ->(user) do
+    if user.admin?
+      where("visibility <> ? And author_id = ? AND project_id IS NULL", VISIBILITY_ROLES, user.id)
+    else
+        where("visibility = ? And author_id = ? AND project_id IS NULL", VISIBILITY_PRIVATE, user.id)
+     end
+  end
+
+  def self.global_for_project(user = User.current, project_id)
+    scope = joins("INNER JOIN #{Project.table_name} ON #{table_name}.project_id = #{Project.table_name}.id").
+      where("#{table_name}.project_id = ?", project_id)
+    if user.admin?
+      #scope.where("#{table_name}.visibility <> ?", VISIBILITY_PRIVATE)
+      scope
+    elsif user.memberships.any?
+      scope.where(
+        "author_id = ?" +
+        " OR #{table_name}.visibility IN (?, ?)" +
+        " OR (#{table_name}.visibility = ? AND #{table_name}.id IN (" +
+        "SELECT DISTINCT res.id FROM #{table_name} res" +
+        " INNER JOIN responses_roles res_ro on res_ro.response_id = res.id" +
+        " INNER JOIN #{MemberRole.table_name} mr ON mr.role_id = res_ro.role_id" +
+        " INNER JOIN #{Member.table_name} m ON m.id = mr.member_id AND m.user_id = ?" +
+        " INNER JOIN #{Project.table_name} p ON p.id = m.project_id AND m.project_id = ?))",
+        user.id, VISIBILITY_PRIVATE, VISIBILITY_PUBLIC, VISIBILITY_ROLES, user.id, project_id)
+    end
+  end
 
   def allowed_target_projects
     Project.active

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -47,8 +47,8 @@ class Response < ActiveRecord::Base
       scope
     elsif user.memberships.any?
       scope.where(
-        "author_id = ?" +
-        " OR #{table_name}.visibility IN (?, ?)" +
+        "author_id = ? AND #{table_name}.visibility = ?" +
+        " OR #{table_name}.visibility = ?" +
         " OR (#{table_name}.visibility = ? AND #{table_name}.id IN (" +
         "SELECT DISTINCT res.id FROM #{table_name} res" +
         " INNER JOIN responses_roles res_ro on res_ro.response_id = res.id" +

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -63,11 +63,13 @@ class Response < ActiveRecord::Base
     Project.active
   end
 
-  def self.available_for(user: User.current, status: nil, tracker: nil)
-    responses = Response.active.visible_by(user)
+  def self.available_for(user: User.current, status: nil, tracker: nil, project_id: nil)
+    private_responses = Response.active.private_for_user(user)
+    global_responses = Response.active.global_for_project(user, project_id)
+    responses = private_responses.to_a + global_responses.to_a
     responses = responses.select { |r| r.initial_status_ids.include?(status.id.to_s) } if status.present?
     responses = responses.select { |r| r.tracker_ids.include?(tracker.id.to_s) } if tracker.present?
-    responses
+    responses.uniq
   end
 
   # Returns true if usr or current user is allowed to view the response

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -8,6 +8,8 @@ class Response < ActiveRecord::Base
 
   belongs_to :final_status, class_name: 'IssueStatus'
   belongs_to :author, :class_name => 'User'
+  belongs_to :project
+  has_and_belongs_to_many :roles, :foreign_key => "response_id", :join_table => "responses_roles", :dependent => :delete_all
 
   safe_attributes "name", "initial_status_ids", "final_status_id",
                   "time_limit", "note",
@@ -24,6 +26,12 @@ class Response < ActiveRecord::Base
   scope :visible_by, ->(user) { where("is_private = ? OR author_id = ?", false, user.id) }
 
   before_save :remove_empty_value_from_serialized_field
+
+  VISIBILITY_PRIVATE = 0
+  VISIBILITY_ROLES   = 1
+  VISIBILITY_PUBLIC  = 2
+
+  validates :visibility, :inclusion => {:in => [VISIBILITY_PUBLIC, VISIBILITY_ROLES, VISIBILITY_PRIVATE]}
 
   def allowed_target_projects
     Project.active

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -15,7 +15,8 @@ class Response < ActiveRecord::Base
                   "time_limit", "note",
                   "author_id", "project_ids",
                   "enabled", "organization_ids",
-                  "tracker_ids", "is_private"
+                  "tracker_ids", "is_private",
+                  "project_id", "visibility"
 
   validates_presence_of :name
   validates_presence_of :author, :if => Proc.new { |response| response.new_record? || response.author_id_changed? }
@@ -27,16 +28,16 @@ class Response < ActiveRecord::Base
   before_save :remove_empty_value_from_serialized_field
 
   VISIBILITY_PRIVATE = 0
-  VISIBILITY_PUBLIC  = 2
   VISIBILITY_ROLES   = 1
+  VISIBILITY_PUBLIC  = 2
 
   validates :visibility, :inclusion => {:in => [VISIBILITY_PUBLIC, VISIBILITY_ROLES, VISIBILITY_PRIVATE]}
   scope :private_for_user, ->(user) do
     if user.admin?
       where("visibility <> ? And author_id = ? AND project_id IS NULL", VISIBILITY_ROLES, user.id)
     else
-        where("visibility = ? And author_id = ? AND project_id IS NULL", VISIBILITY_PRIVATE, user.id)
-     end
+      where("visibility = ? And author_id = ? AND project_id IS NULL", VISIBILITY_PRIVATE, user.id)
+    end
   end
 
   def self.global_for_project(user = User.current, project_id)

--- a/app/views/hooks/_view_sidebar_manage_responses.html.erb
+++ b/app/views/hooks/_view_sidebar_manage_responses.html.erb
@@ -1,6 +1,10 @@
 <% if User.current.admin? || User.current.allowed_to?(:create_prefabricated_responses, @project, :global => true) %>
   <h3><%= l(:label_responses) %></h3>
-  <% project_id = @project.present? ? @project.id : nil %>
-  <%= link_to l(:label_new_response), new_response_path(project_id) %><br>
-  <%= link_to l("label_all_responses"), responses_path %>
+  <% if @project.present? %>
+    <%= link_to l(:label_new_response_for_project), project_new_response_path(@project.id) %><br>
+    <%= link_to l(:label_all_responses_for_project), project_responses_path(@project.id) %>
+  <% else %>
+    <%= link_to l(:label_new_response_private), new_response_path %><br>
+    <%= link_to l(:label_all_responses_private), responses_path %>
+  <% end %>
 <% end %>

--- a/app/views/hooks/_view_sidebar_manage_responses.html.erb
+++ b/app/views/hooks/_view_sidebar_manage_responses.html.erb
@@ -1,4 +1,6 @@
-<% if User.current.admin? || User.current.allowed_to?(:create_responses, @project) %>
+<% if User.current.admin? || User.current.allowed_to?(:create_prefabricated_responses, @project, :global => true) %>
   <h3><%= l(:label_responses) %></h3>
+  <% project_id = @project.present? ? @project.id : nil %>
+  <%= link_to l(:label_new_response), new_response_path(project_id) %><br>
   <%= link_to l("label_all_responses"), responses_path %>
 <% end %>

--- a/app/views/hooks/_view_sidebar_manage_responses.html.erb
+++ b/app/views/hooks/_view_sidebar_manage_responses.html.erb
@@ -1,7 +1,7 @@
 <% if User.current.admin? || User.current.allowed_to?(:create_prefabricated_responses, @project, :global => true) %>
   <h3><%= l(:label_responses) %></h3>
   <% if @project.present? %>
-    <%= link_to l(:label_new_response_for_project), project_new_response_path(@project.id) %><br>
+    <%= link_to l(:label_new_response_for_project), new_project_response_path(@project.id) %><br>
     <%= link_to l(:label_all_responses_for_project), project_responses_path(@project.id) %>
   <% else %>
     <%= link_to l(:label_new_response_private), new_response_path %><br>

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -6,6 +6,9 @@
     <div id="response_attributes">
 
       <p><%= f.text_field :name, { label: l(:field_name), required: false, size: 80 } %></p>
+      <p>
+        <%= f.check_box :enabled, { label: l(:label_enabled) } %>
+      </p>
       <%= hidden_field_tag 'response[project_id]', @response.project.present? ? @response.project.id : ''  %>
       <% if User.current.admin? ||
       User.current.allowed_to?(:manage_public_responses, @response.project) %>

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -6,14 +6,29 @@
     <div id="response_attributes">
 
       <p><%= f.text_field :name, { label: l(:field_name), required: false, size: 80 } %></p>
-
-      <p>
-        <%= f.check_box :enabled, { label: l(:label_enabled) } %>
-      </p>
-
-      <p>
-        <%= f.check_box :is_private, { label: l(:field_is_private) } %>
-      </p>
+      <%= hidden_field_tag 'response[project_id]', @response.project.present? ? @response.project.id : ''  %>
+      <% if User.current.admin? ||
+      User.current.allowed_to?(:manage_public_responses, @response.project) %>
+        <p>
+          <label><%=l(:field_visible)%></label>
+          <label class="block"><%= f.radio_button :visibility,   Response::VISIBILITY_PRIVATE %>
+            <%= l(:label_visibility_private) %>
+         </label>
+          <label class="block"><%= f.radio_button :visibility,   Response::VISIBILITY_PUBLIC %>
+           <%= l(:label_visibility_public) %>
+          </label>
+          <% if @response.project.present? %>
+            <label class="block">
+              <%= f.radio_button :visibility,   Response::VISIBILITY_ROLES %>
+              <%= l(:label_visibility_roles) %>:
+            </label>
+              <% Role.givable.sorted.each do |role| %>
+                <label class="block role-visibility"><%= check_box_tag 'response[role_ids][]', role.id, @response.roles.include?(role), :id => nil %> <%= role.name %></label>
+              <% end %>
+              <%= hidden_field_tag 'response[role_ids][]', '' %>
+          <% end %>
+        </p>
+      <% end %>
 
       <p>
         <%= f.select :initial_status_ids,

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -111,3 +111,12 @@
   <%= submit_tag l(:button_save) %>
 
 <% end %>
+<script>
+  $(document).ready(function(){
+    $("input[name='response[visibility]']").change(function(){
+      var roles_checked = $('#response_visibility_1').is(':checked');
+      var private_checked = $('#response_visibility_0').is(':checked');
+      $("input[name='response[role_ids][]'][type=checkbox]").attr('disabled', !roles_checked);
+    }).trigger('change');
+  });
+</script>

--- a/app/views/responses/edit.html.erb
+++ b/app/views/responses/edit.html.erb
@@ -1,5 +1,9 @@
 <div class=contextual>
-  <%= link_to l(:label_all_responses), responses_path, class: "icon-prefabricated-responses" %>
+  <% if @response.project.present? %>
+    <%= link_to l(:label_all_responses_for_project), project_responses_path(@response.project.id), class: "icon-prefabricated-responses" %>
+  <% else %>
+    <%= link_to l(:label_all_responses_private), responses_path, class: "icon-prefabricated-responses" %>
+  <% end %>
 </div>
 
 <h2><%= "#{l(:label_edit_response)}" %></h2>

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="contextual">
   <% if @project_id.present? %>
-    <%= link_to l(:label_new_response_for_project), project_new_response_path(@project_id), :class => 'icon icon-add' %>
+    <%= link_to l(:label_new_response_for_project), new_project_response_path(@project_id), :class => 'icon icon-add' %>
   <% else %>
     <%= link_to l(:label_new_response_private), new_response_path, :class => 'icon icon-add' %>
   <% end %>
@@ -52,7 +52,7 @@
           <!-- <td><%= l 'time_in_days', days: response.time_limit %></td> -->
 
           <td class="buttons">
-            <%= link_to l(:button_show), show_response_path(response), :class => 'icon icon-list' %>
+            <%= link_to l(:button_show), response_path(response), :class => 'icon icon-list' %>
             <%= link_to l(:button_edit), edit_response_path(response), :class => 'icon icon-edit' %>
             <%= delete_link response_path(response) %>
           </td>

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -53,8 +53,10 @@
 
           <td class="buttons">
             <%= link_to l(:button_show), response_path(response), :class => 'icon icon-list' %>
-            <%= link_to l(:button_edit), edit_response_path(response), :class => 'icon icon-edit' %>
-            <%= delete_link response_path(response) %>
+            <% if User.current.admin? || response.author == User.current %>
+              <%= link_to l(:button_edit), edit_response_path(response), :class => 'icon icon-edit' %>
+              <%= delete_link response_path(response) %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -1,9 +1,11 @@
 <% html_title(l(:label_responses)) %>
 
 <div class="contextual">
-  <%= link_to(l(:label_new_response),
-              {:controller => 'responses', :action => 'new'},
-              :class => 'icon icon-add', :method => :get) %>
+  <% if @project_id.present? %>
+    <%= link_to l(:label_new_response_for_project), project_new_response_path(@project_id), :class => 'icon icon-add' %>
+  <% else %>
+    <%= link_to l(:label_new_response_private), new_response_path, :class => 'icon icon-add' %>
+  <% end %>
 </div>
 
 <h2><span class="icon icon-prefabricated-responses"><%= h "#{l(:label_responses)}" %></span></h2>
@@ -50,7 +52,7 @@
           <!-- <td><%= l 'time_in_days', days: response.time_limit %></td> -->
 
           <td class="buttons">
-            <%= link_to l(:button_show), response_path(response), :class => 'icon icon-list' %>
+            <%= link_to l(:button_show), show_response_path(response), :class => 'icon icon-list' %>
             <%= link_to l(:button_edit), edit_response_path(response), :class => 'icon icon-edit' %>
             <%= delete_link response_path(response) %>
           </td>

--- a/app/views/responses/new.html.erb
+++ b/app/views/responses/new.html.erb
@@ -1,5 +1,9 @@
 <div class=contextual>
-  <%= link_to l(:label_all_responses), responses_path, class: "icon-prefabricated-responses" %>
+  <% if @response.project.present? %>
+    <%= link_to l(:label_all_responses_for_project), project_responses_path(@response.project.id), class: "icon-prefabricated-responses" %>
+  <% else %>
+    <%= link_to l(:label_all_responses_private), responses_path, class: "icon-prefabricated-responses" %>
+  <% end %>
 </div>
 
 <h2><%=l(:label_new_response)%></h2>

--- a/app/views/responses/new.html.erb
+++ b/app/views/responses/new.html.erb
@@ -5,9 +5,11 @@
     <%= link_to l(:label_all_responses_private), responses_path, class: "icon-prefabricated-responses" %>
   <% end %>
 </div>
-
-<h2><%=l(:label_new_response)%></h2>
-
+<% if @response.project.present? %>
+  <h2><%=l(:label_new_response_for_project)%></h2>
+<% else %>
+  <h2><%=l(:label_new_response_private)%></h2>
+<% end %>
 <div id="all_attributes">
   <%= render :partial => 'responses/form' %>
 </div>

--- a/app/views/responses/show.html.erb
+++ b/app/views/responses/show.html.erb
@@ -1,5 +1,9 @@
 <div class=contextual>
-  <%= link_to l(:label_all_responses), responses_path, class: "icon-prefabricated-responses" %>
+  <% if @response.project.present? %>
+    <%= link_to l(:label_all_responses_for_project), project_responses_path(@response.project.id), class: "icon-prefabricated-responses" %>
+  <% else %>
+    <%= link_to l(:label_all_responses_private), responses_path, class: "icon-prefabricated-responses" %>
+  <% end %>
 </div>
 
 <h2><%= @response.name %></h2>

--- a/app/views/responses/show.html.erb
+++ b/app/views/responses/show.html.erb
@@ -10,8 +10,9 @@
 
 <fieldset id="response">
   <legend><%= l(:label_prefabricated_response) %></legend>
-  <span class="label" style="float: right;"><%= link_to l(:button_edit), edit_response_path(@response) %></span>
-
+  <% if User.current.admin? || @response.author == User.current %>
+    <span class="label" style="float: right;"><%= link_to l(:button_edit), edit_response_path(@response) %></span>
+  <% end %>
   <span class="label"><%= l(:label_enabled) %></span> :
   <span class="value <%= @response.enabled ? 'icon icon-ok' : 'icon icon-not-ok' %>" style="margin-left: 10px;"></span><br/>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
   label_all_responses_for_project: View all responses on this project
   label_all_responses_private: View my private responses
   field_initial_status_plural: Initial statues
-  label_enabled: Enabled
-  field_final_status: Final status
-  label_auto_update_note: Auto update note
-  hint_no_final_status: No final status
+  # label_enabled: Enabled
+  # field_final_status: Final status
+  # label_auto_update_note: Auto update note
+  # hint_no_final_status: No final status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,3 +9,8 @@ en:
   label_new_response_private: Add a private response
   label_all_responses_for_project: View all responses on this project
   label_all_responses_private: View my private responses
+  field_initial_status_plural: Initial statues
+  label_enabled: Enabled
+  field_final_status: Final status
+  label_auto_update_note: Auto update note
+  hint_no_final_status: No final status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,7 @@ en:
   button_send: Send
   label_responses: Prefabricated responses
   label_change_note_of_response: Edit the note of this answer
+  label_new_response_for_project: Add a response on this project
+  label_new_response_private: Add a private response
+  label_all_responses_for_project: View all responses on this project
+  label_all_responses_private: View my private responses

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,3 +14,4 @@ en:
   # field_final_status: Final status
   # label_auto_update_note: Auto update note
   # hint_no_final_status: No final status
+  label_author: Autor

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -13,8 +13,8 @@ fr:
   label_new_response_private: Ajouter une réponse privée
   label_all_responses_for_project: Voir toutes les réponses sur ce projet
   label_all_responses_private: Voir mes réponses privées
-  field_initial_status_plural: Initials statuts
-  label_enabled: Enabled
-  field_final_status: Statuts finals
-  label_auto_update_note: Note de mise à jour automatique
-  hint_no_final_status: Pas de statut final
+  # field_initial_status_plural: Initials statuts
+  # label_enabled: Enabled
+  # field_final_status: Statuts finals
+  # label_auto_update_note: Note de mise à jour automatique
+  # hint_no_final_status: Pas de statut final

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -13,3 +13,8 @@ fr:
   label_new_response_private: Ajouter une réponse privée
   label_all_responses_for_project: Voir toutes les réponses sur ce projet
   label_all_responses_private: Voir mes réponses privées
+  field_initial_status_plural: Initials statuts
+  label_enabled: Enabled
+  field_final_status: Statuts finals
+  label_auto_update_note: Note de mise à jour automatique
+  hint_no_final_status: Pas de statut final

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -18,3 +18,4 @@ fr:
   # field_final_status: Statuts finals
   # label_auto_update_note: Note de mise à jour automatique
   # hint_no_final_status: Pas de statut final
+  label_author: Auteur

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -9,3 +9,7 @@ fr:
   button_send: Envoyer
   label_select_all: Tout selectionner
   label_change_note_of_response: Modifier la note de cette réponse
+  label_new_response_for_project: Ajouter une réponse sur ce projet
+  label_new_response_private: Ajouter une réponse privée
+  label_all_responses_for_project: Voir toutes les réponses sur ce projet
+  label_all_responses_private: Voir mes réponses privées

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 RedmineApp::Application.routes.draw do
-  get 'responses/new(/:project_id)', controller: 'responses', action: 'new', as: 'new_response'
-  resources :responses, :except => [:new] do
+  get 'responses/new', to: 'responses#new', as: 'new_response'
+  get 'projects/:project_id/responses/new', to: 'responses#new', as: 'project_new_response'
+
+  get 'responses/', to: 'responses#index', as: 'responses'
+  get 'projects/:project_id/responses/', to: 'responses#index', as: 'project_responses'
+
+  get 'response/:id', controller: 'responses', action: 'show', as: 'show_response'
+  resources :responses, :except => [:new, :index, :show] do
     collection do
       post :add
       post :apply

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,15 @@
 RedmineApp::Application.routes.draw do
-  get 'responses/new', to: 'responses#new', as: 'new_response'
-  get 'projects/:project_id/responses/new', to: 'responses#new', as: 'project_new_response'
 
-  get 'responses/', to: 'responses#index', as: 'responses'
-  get 'projects/:project_id/responses/', to: 'responses#index', as: 'project_responses'
+  resources :projects do
+    resources :responses, :only => [:index, :new, :create]
+  end
 
-  get 'response/:id', controller: 'responses', action: 'show', as: 'show_response'
-  resources :responses, :except => [:new, :index, :show] do
+  resources :responses do
     collection do
       post :add
       post :apply
       post :update_note
     end
   end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 RedmineApp::Application.routes.draw do
-  resources :responses do
+  get 'responses/new(/:project_id)', controller: 'responses', action: 'new', as: 'new_response'
+  resources :responses, :except => [:new] do
     collection do
       post :add
       post :apply

--- a/db/migrate/20220329085748_add_visibility_attribute_to_responses.rb
+++ b/db/migrate/20220329085748_add_visibility_attribute_to_responses.rb
@@ -1,0 +1,6 @@
+class AddVisibilityAttributeToResponses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :responses, :visibility, :integer, default: 0
+    add_column :responses, :project_id, :integer
+  end
+end

--- a/db/migrate/20220329113520_create_responses_roles.rb
+++ b/db/migrate/20220329113520_create_responses_roles.rb
@@ -1,0 +1,8 @@
+class CreateResponsesRoles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :responses_roles, :id => false do |t|
+      t.column :response_id, :integer, :null => false
+      t.column :role_id, :integer, :null => false
+    end
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -25,6 +25,7 @@ Redmine::Plugin.register :redmine_prefabricated_responses do
        :caption => :label_prefabricated_responses,
        :html => { :class => 'icon' }
   project_module :prefabricated_responses do
+    permission :manage_public_responses, { :responses => [:index, :new, :create, :edit, :update, :destroy] }
     permission :use_prefabricated_responses, { :responses => [:index] }
     permission :create_prefabricated_responses, { :responses => [:index, :new, :create, :edit, :update, :destroy] }
     permission :make_public_their_prefabricated_responses, { :responses => [:index, :new, :create, :edit, :update, :destroy] }

--- a/lib/redmine_prefabricated_responses/issue_patch.rb
+++ b/lib/redmine_prefabricated_responses/issue_patch.rb
@@ -9,7 +9,7 @@ module RedminePrefabricatedResponses
 
     def available_responses(user = User.current)
       return [] unless user.allowed_to?(:edit_issues, project) || (user.allowed_to?(:edit_own_issues, project) && user == author)
-      responses = Response.available_for(user: user, status: self.status, tracker: self.tracker)
+      responses = Response.available_for(user: user, status: self.status, tracker: self.tracker, project_id: project.id)
       # TODO Filter available responses for current issue and current user
       responses
     end

--- a/spec/fixtures/responses.yml
+++ b/spec/fixtures/responses.yml
@@ -8,6 +8,8 @@ one:
   name: Close issue
   author_id: 2
   is_private: false
+  project_id: Null
+  visibility: 0
 two:
   id: 2
   initial_status_ids: ['1', '2']
@@ -18,6 +20,8 @@ two:
   name: This one does not udpate the status
   author_id: 2
   is_private: false
+  project_id: 1
+  visibility: 0
 three:
   id: 3
   initial_status_ids: ['1', '2']
@@ -28,3 +32,54 @@ three:
   name: Private response
   author_id: 2
   is_private: true
+  project_id: 1
+  visibility: 2
+four:
+  id: 4
+  initial_status_ids: ['1', '2', '3']
+  final_status_id:
+  note: Thank you.
+  enabled: true
+  tracker_ids: [ ]
+  name: Public response
+  author_id: 1
+  is_private: true
+  project_id: Null
+  visibility: 2
+five:
+  id: 5
+  initial_status_ids: ['1', '2', '3', '4', '5']
+  final_status_id:
+  note: Thank you.
+  enabled: true
+  tracker_ids: ['1']
+  name: Private response of admin
+  author_id: 1
+  is_private: true
+  project_id: Null
+  visibility: 0
+six:
+  id: 6
+  initial_status_ids: ['2']
+  final_status_id:
+  note: Well.
+  enabled: true
+  tracker_ids: ['1']
+  name: Private response of admin on project 1
+  author_id: 1
+  is_private: true
+  project_id: 1
+  visibility: 0
+seven:
+  id: 7
+  initial_status_ids: ['1', '2', '4']
+  final_status_id:
+  note: Well.
+  enabled: true
+  tracker_ids: ['1', '2']
+  name: Response of admin on project 1 for manager role
+  author_id: 1
+  is_private: true
+  project_id: 1
+  visibility: 1
+

--- a/spec/fixtures/responses_roles.yml
+++ b/spec/fixtures/responses_roles.yml
@@ -1,0 +1,3 @@
+one:
+  response_id: 7
+  role_id: 2

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe Issue, :type => :model do
       expect(issue_7.available_responses).to include response
     end
 
+    it "returns an array of responses when(initial_status_ids contains status new) (tracker_ids contains bug), " do
+      User.current = User.find(1)
+      res = Response.find(6)
+
+      expect(issue_7.available_responses.size).to eq 3
+      expect(issue_7.available_responses).to_not include(res)
+
+      res.initial_status_ids << "1"
+      res.save
+
+      expect(issue_7.available_responses.size).to eq 4
+      expect(issue_7.available_responses).to include(res)
+    end
   end
 
   context "add responses" do

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Response, :type => :model do
 
-  fixtures :responses, :issues, :trackers, :issue_statuses, :projects, :enumerations
+  fixtures :responses, :issues, :trackers, :issue_statuses, :projects, :enumerations, :responses_roles
 
   let!(:response) { Response.find(1) }
   let!(:response_without_final_status) { Response.find(2) }
@@ -35,6 +35,36 @@ RSpec.describe Response, :type => :model do
       expect(response).to have_attributes(is_private: false)
     end
 
+    it "has viisbilty" do
+      expect(response).to have_attributes(visibility: 0)
+    end
+
+  end
+
+  describe "scope private_for_user" do
+    it "should show private and public response of admin" do
+      expect(Response.private_for_user(User.find(1)).count).to eq(2)
+    end
+    it "should show only private response of user(not admin)" do
+      expect(Response.private_for_user(User.find(2)).count).to eq(1)
+    end
+  end
+
+  describe "scope global_for_project" do
+
+    it "should show all response on project for user(admin)" do
+      expect(Response.global_for_project(User.find(1), 1).count).to eq(4)
+    end
+
+    it "should show only global response for user(not developer) on project" do
+      expect(Response.global_for_project(User.find(2), 1).count).to eq(2)
+    end
+
+    it "should show global response + (his private response) + response for developper role for user(developper) on project" do
+      member = MemberRole.new(:member_id => 1, :role_id => 2)
+      member.save
+      expect(Response.global_for_project(User.find(2), 1).count).to eq(3)
+    end
   end
 
 end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -42,25 +42,25 @@ RSpec.describe Response, :type => :model do
   end
 
   describe "scope private_for_user" do
-    it "should show private and public response of admin" do
+    it "should show private and public responses when user(admin)" do
       expect(Response.private_for_user(User.find(1)).count).to eq(2)
     end
-    it "should show only private response of user(not admin)" do
+    it "should show only private responses when user(not admin)" do
       expect(Response.private_for_user(User.find(2)).count).to eq(1)
     end
   end
 
   describe "scope global_for_project" do
 
-    it "should show all response on project for user(admin)" do
+    it "should show all responses on project when user(admin)" do
       expect(Response.global_for_project(User.find(1), 1).count).to eq(4)
     end
 
-    it "should show only global response for user(not developer) on project" do
+    it "should show only public responses on project when user(not developer)" do
       expect(Response.global_for_project(User.find(2), 1).count).to eq(2)
     end
 
-    it "should show global response + (his private response) + response for developper role for user(developper) on project" do
+    it "should show public responses + his private responses + response for developper role on project when user(developper)" do
       member = MemberRole.new(:member_id => 1, :role_id => 2)
       member.save
       expect(Response.global_for_project(User.find(2), 1).count).to eq(3)


### PR DESCRIPTION
- La possibilité d’associer une réponse au projet en ajoutant la colonne project_id(qui peut être à nil ) dans la table de réponse.
- La réponse a trois types de visibilité (privée, public, visibilité dépend du rôle) 
- Partager une réponse
